### PR TITLE
Feature/love 21 auth token

### DIFF
--- a/pride/App.js
+++ b/pride/App.js
@@ -11,6 +11,7 @@ import HomeScreen from './screens/Onboarding/components/HomeScreen';
 import { MainColours, MainStyles } from './styles/core';
 import { NavigationContainer } from '@react-navigation/native';
 import CustomBottomTabBar from './navigation/CustomBottomTabBar';
+import useAuthProvider from './screens/Onboarding/hooks/useAuthProvider';
 
 const Loading = () => {
   return (
@@ -24,6 +25,8 @@ const Loading = () => {
 export default function App() {
   const [loading, setLoading] = useState(true);
   const [viewedOnboarding, setViewedOnboarding] = useState(false);
+
+  const [userToken, setUserToken] = useState(null);
 
   const checkOnboarding = async () => {
     try {
@@ -43,6 +46,25 @@ export default function App() {
     checkOnboarding()
   }, [])
 
+  const checkUserToken = async () => {
+    try {
+      const token = await AsyncStorage.getItem('@userToken');
+
+      if (token != null) {
+        setUserToken(token);
+      }
+    } catch(err) {
+      console.log("@checkUserToken error: ", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    checkUserToken()
+    console.log("@userToken: ", userToken)
+  }, [userToken])
+
   return (
     // <View style={MainStyles.container}>
     //   <Onboarding/>
@@ -50,7 +72,8 @@ export default function App() {
     // </View>
     <NavigationContainer>
       <StatusBar style="auto" />
-      <Onboarding/>
+      {/* <Onboarding/> */}
+      { userToken ? <CustomBottomTabBar/> : <Onboarding/> }
       {/* <CustomBottomTabBar/> */}
     </NavigationContainer>
   );

--- a/pride/App.js
+++ b/pride/App.js
@@ -51,8 +51,8 @@ export default function App() {
     // </View>
     <NavigationContainer>
       <StatusBar style="auto" />
-      {/* <Onboarding/> */}
-      <CustomBottomTabBar/>
+      <Onboarding/>
+      {/* <CustomBottomTabBar/> */}
     </NavigationContainer>
   );
 }

--- a/pride/App.js
+++ b/pride/App.js
@@ -22,7 +22,6 @@ const Loading = () => {
 
 
 export default function App() {
-
   const [loading, setLoading] = useState(true);
   const [viewedOnboarding, setViewedOnboarding] = useState(false);
 

--- a/pride/package-lock.json
+++ b/pride/package-lock.json
@@ -20,6 +20,7 @@
         "react": "17.0.1",
         "react-dom": "17.0.1",
         "react-native": "0.64.3",
+        "react-native-pkce-challenge": "^3.0.0",
         "react-native-really-awesome-button": "^1.6.0",
         "react-native-safe-area-context": "3.3.2",
         "react-native-screens": "~3.10.1",
@@ -4128,6 +4129,11 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+    },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
@@ -7976,6 +7982,14 @@
         "flow-parser": "^0.121.0",
         "jscodeshift": "^0.11.0",
         "nullthrows": "^1.1.1"
+      }
+    },
+    "node_modules/react-native-pkce-challenge": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-pkce-challenge/-/react-native-pkce-challenge-3.0.0.tgz",
+      "integrity": "sha512-sgFanvpt1oOMuB3EVjYyS+AVlo/KjZ0Hgb8zHG/KMyHv1ueXYORt99iw8t5zPnyYyq4/teTLdWc9cffli2ADSQ==",
+      "dependencies": {
+        "crypto-js": "3.3.0"
       }
     },
     "node_modules/react-native-really-awesome-button": {
@@ -13079,6 +13093,11 @@
         }
       }
     },
+    "crypto-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+    },
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
@@ -16091,6 +16110,14 @@
         "flow-parser": "^0.121.0",
         "jscodeshift": "^0.11.0",
         "nullthrows": "^1.1.1"
+      }
+    },
+    "react-native-pkce-challenge": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-pkce-challenge/-/react-native-pkce-challenge-3.0.0.tgz",
+      "integrity": "sha512-sgFanvpt1oOMuB3EVjYyS+AVlo/KjZ0Hgb8zHG/KMyHv1ueXYORt99iw8t5zPnyYyq4/teTLdWc9cffli2ADSQ==",
+      "requires": {
+        "crypto-js": "3.3.0"
       }
     },
     "react-native-really-awesome-button": {

--- a/pride/package.json
+++ b/pride/package.json
@@ -22,6 +22,7 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-native": "0.64.3",
+    "react-native-pkce-challenge": "^3.0.0",
     "react-native-really-awesome-button": "^1.6.0",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.10.1",

--- a/pride/screens/Onboarding/components/SignInButton.js
+++ b/pride/screens/Onboarding/components/SignInButton.js
@@ -6,7 +6,7 @@ import { MainStyles } from '../../../styles/core';
 import useAuthProvider from '../hooks/useAuthProvider';
 
 const SignInButton = () => {
-  const { promptAsync, affairResponse } = useAuthProvider();
+  const { promptAsync } = useAuthProvider();
 
   return (
     <View style={MainStyles.container}>

--- a/pride/screens/Onboarding/hooks/useAuthProvider.js
+++ b/pride/screens/Onboarding/hooks/useAuthProvider.js
@@ -3,10 +3,10 @@ import { Alert } from 'react-native';
 
 import useAzureAuth from './useAzureAuth';
 
-const useAuthProvider = () => {
-  const BASE_API_ENDPOINT = process.env.BASE_API_ENDPOINT;
+const BASE_API_ENDPOINT = process.env.BASE_API_ENDPOINT;
 
-  const { promptAsync, tokenResponse } = useAzureAuth();
+const useAuthProvider = () => {
+  const { response, promptAsync, tokenResponse, azureAuthError } = useAzureAuth();
 
   // TODO: Handle affair response
   const [affairResponse, setAffairResponse] = useState({});
@@ -18,7 +18,6 @@ const useAuthProvider = () => {
   const sendToAffair = useCallback(
     async (tokenResponse) => {
       try {
-        // Do POST request to login endpoint, including access token in body
         const serverResponse = await fetch(loginEndpoint, {
           method: 'POST',
           headers: {
@@ -30,11 +29,16 @@ const useAuthProvider = () => {
           })
         });
 
-        const responseJson = await serverResponse.json();
+        console.log("[D] ACCESS TOKEN => ", tokenResponse.accessToken);
+        console.log("[D] ID TOKEN => ", tokenResponse.idToken);
+        console.log("[D] CODE => ", tokenResponse.code);
 
-        // If response is succesful, set the response and alert user
+        const responseJson = await serverResponse.json();
+        
+        console.log("[D] SERVER RESPONSE => ", responseJson)
+
         setAffairResponse(responseJson);
-        Alert.alert('Affair response', JSON.stringify(affairResponse));
+        Alert.alert('Affair response', JSON.stringify(responseJson));
 
         return responseJson;
       } catch (e) {

--- a/pride/screens/Onboarding/hooks/useAzureAuth.js
+++ b/pride/screens/Onboarding/hooks/useAzureAuth.js
@@ -1,43 +1,83 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import {
   makeRedirectUri,
   useAuthRequest,
-  useAutoDiscovery
+  useAutoDiscovery,
+  exchangeCodeAsync,
+  CodeChallengeMethod,
 } from 'expo-auth-session';
 
+import { pkceChallenge } from 'react-native-pkce-challenge';
+
+const APP_CLIENT_ID = process.env.APP_CLIENT_ID;
+const TENANT_ID = process.env.TENANT_ID;
+
+const challenge = pkceChallenge();
+
 const useAzureAuth = () => {
-  const APP_CLIENT_ID = process.env.APP_CLIENT_ID;
-  const TENANT_ID = process.env.TENANT_ID;
+  const [azureAuthError, setAzureAuthError] = useState(null);
+  const [tokenResponse, setTokenResponse] = useState(null);
 
   const discovery = useAutoDiscovery(
     `https://login.microsoftonline.com/${TENANT_ID}/v2.0`
   );
+  
+  const redirectUri = makeRedirectUri({
+    /*
+      scheme: The URI [scheme]:// to be used in bare and standalone. 
+      If undefined, the scheme property of your app.json or 
+      app.config.js will be used instead. 
+    */
+    scheme: 'pride',
+  })
 
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: APP_CLIENT_ID,
-      scopes: ['openid', 'profile', 'email', 'offline_access'],
-      redirectUri: makeRedirectUri({
-        /*
-          scheme: The URI [scheme]:// to be used in bare and standalone. 
-          If undefined, the scheme property of your app.json or 
-          app.config.js will be used instead. 
-        */
-        scheme: 'your.app'
-      })
+      scopes: ['openid', 'profile', 'email', 'offline_access', 'User.Read'],
+      redirectUri,
+      codeChallenge: challenge.codeChallenge,
+      codeChallengeMethod: CodeChallengeMethod.S256
     },
     discovery
   );
 
   useEffect(() => {
-    if (response) console.log(`[D] RESPONSE => ${JSON.stringify(response)}`);
-  }, [response]);  
+    if (response?.type === 'success') {
+      const exchangeResponse = exchangeCodeAsync(
+        {
+          clientId: APP_CLIENT_ID,
+          code: response.params.code,
+          redirectUri,
+          scopes: ['openid', 'profile', 'email', 'offline_access', 'User.Read'],
+          extraParams: {
+            code_verifier: request?.codeVerifier ? request.codeVerifier : ''
+          }
+        },
+        {
+          tokenEndpoint: `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/token`
+        }
+      );
+
+      exchangeResponse
+        .then(res => {
+          if (res.accessToken){
+            setTokenResponse(res);
+          }
+        })
+        .catch(e => {
+          setAzureAuthError(e);
+        });
+    }
+  }, [response, request?.codeVerifier, tokenResponse]);  
 
   return {
     request,
-    tokenResponse: response,
-    promptAsync
+    response,
+    promptAsync,
+    tokenResponse,
+    azureAuthError,
   };
 };
 

--- a/pride/screens/PostScreen/index.js
+++ b/pride/screens/PostScreen/index.js
@@ -1,9 +1,16 @@
-import { StyleSheet, Text, View } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Button, StyleSheet, Text, View } from 'react-native';
 
 const PostScreen = () => {
   return (
     <View>
       <Text>PostScreen</Text>
+      <Button
+        onPress={async () => {
+          await AsyncStorage.removeItem('@userToken');
+        }}
+        title='Remove token'
+      ></Button>
     </View>
   );
 };

--- a/pride/styles/core.js
+++ b/pride/styles/core.js
@@ -1,4 +1,4 @@
-import { StyleSheet } from "react-native";
+import { StyleSheet, Platform } from "react-native";
 
 const MainColours = {
   primary: "#000",
@@ -43,7 +43,7 @@ const MainStyles = StyleSheet.create({
   },
 
   title: {
-    fontWeight: '800',
+    fontWeight: Platform.OS == 'ios' ? '800' : '700',
     fontSize: 28,
     marginBottom: 10,
     color: '#493d8a',
@@ -51,7 +51,7 @@ const MainStyles = StyleSheet.create({
   },
 
   description: {
-    fontWeight: '800',
+    fontWeight: Platform.OS == 'ios' ? '800' : '700',
     color: '#62656b',
     textAlign: 'center',
     paddingHorizontal: 64,


### PR DESCRIPTION
**Description**
Cuando un usuario inicia sesión desde front-end, su sesión se registra en stage. Pero en la respuesta de la sesión no se responde con ningún token de autorización; este se crea, pero no se regresa. Es importante regresarlo pues este es el que se usará como autenticador en las peticiones que se hagan al server.

**Purpose**
Tener un token que se pueda almacenar en el front-end con async storage, y así poder realizar peticiones.

**Acceptance Criteria**
Cuando se inicia sesión desde React Native, se debe regresar el token de autenticación desde el back-end. Eso será suficiente para validar esta tarea.

**Testing Steps**
1. Iniciar sesión normalmente desde React Native
2. Ingresar con datos validos
3. Verificar que la respuesta de React Native haga referencia a que se inicio sesión correctamente.
4. Volver a ingresar pero con datos invalidos
5. Verificar que la respuesta de React Native haga referencia a que no se pudo validar la sesión.